### PR TITLE
fix(alert-modal): center delete icon

### DIFF
--- a/apps/app/web/src/components/organisms/modals/WidgetAlerts.modal.tsx
+++ b/apps/app/web/src/components/organisms/modals/WidgetAlerts.modal.tsx
@@ -115,7 +115,7 @@ const WidgetAlertsModal = ({ open, setOpenModal, widget }: Props) => {
                       </IconButton>
                     )}
                   </TableCell>
-                  <TableCell>
+                  <TableCell align="right">
                     <IconButton
                       color="error"
                       size="large"


### PR DESCRIPTION
Before:
<img width="571" alt="Screenshot 2023-10-03 at 11 33 03" src="https://github.com/metrikube/app/assets/37811574/16caab73-0905-4f37-84ff-8726ec383e02">

After:
<img width="570" alt="Screenshot 2023-10-03 at 11 32 41" src="https://github.com/metrikube/app/assets/37811574/c7355a2b-ddee-46f9-96ca-74551c16e2fc">
